### PR TITLE
Trigger change event when setting input value

### DIFF
--- a/src/js/getmdl-select.js
+++ b/src/js/getmdl-select.js
@@ -15,6 +15,13 @@
         [].forEach.call(list, function (li) {
             li.onclick = function () {
                 input.value = li.textContent;
+                if ("createEvent" in document) {
+                    var evt = document.createEvent("HTMLEvents");
+                    evt.initEvent("change", false, true);
+                    input.dispatchEvent(evt);
+                } else {
+                    input.fireEvent("onchange");
+                }
             }
         });
     };


### PR DESCRIPTION
With this change you can listen to the change event on the getmdl-select just as you can do with a native `input` `select`. The event is triggered on the text input.