### PR TITLE
Fixed window.onload overload bug

### DIFF
--- a/src/js/getmdl-select.js
+++ b/src/js/getmdl-select.js
@@ -1,13 +1,14 @@
 {
     'use strict';
-    window.onload = function () {
+
+    window.addEventListener('load', function () {
         getmdlSelect.init('.getmdl-select');
         document.addEventListener("DOMNodeInserted", function (ev) {
             if (ev.relatedNode.querySelectorAll(".getmdl-select").length > 0) {
                 componentHandler.upgradeDom();
             }
         }, false);
-    };
+    });
 
     var getmdlSelect = {
         defaultValue : {
@@ -31,7 +32,7 @@
                     input.focus();
                 }
             };
-            
+
             [].forEach.call(list, function (li) {
                 li.onclick = function () {
                     input.value = li.textContent;


### PR DESCRIPTION
window.onload can only be set once. This means that the last script
that sets windows.onload is initialised. To make sure this library can
work together with other libraries we changed we added the callback to
the event listener.