### PR TITLE
Remove defer from material.min.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ To use any MDL component, you must include the minified CSS and JavaScript files
    <!-- getmdl -->
    <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
    <link rel="stylesheet" href="your_path_to/material-design-lite/material.min.css">
-   <script defer src="your_path_to/material-design-lite/material.min.js"></script>   
+   <script src="your_path_to/material-design-lite/material.min.js"></script>   
    <!--getmdl-select-->   
    <link rel="stylesheet" href="path_to/getmdl-select/getmdl-select.min.css">
    <script defer src="path_to/getmdl-select/getmdl-select.min.js"></script>


### PR DESCRIPTION
Hello there!

I ran into an issue when using your library, which will probably be solved by just changing this in the README.md

I do not have the most experience with JavaScript and asynchronous loading, so this might be solvable in a different way.

Explanation of the problem: 
Adding defer would allow this script to execute after the
`getmdl-select.js`
script. For me the problem was that I was setting the
data-selected=true, but in the `setSelectedItem` function it was
requesting dropdown.MaterialTextField, which was not there yet because
the `material.min.js` did not execute yet.