### PR TITLE
Check for string containing true when setting selected item

### DIFF
--- a/src/js/getmdl-select.js
+++ b/src/js/getmdl-select.js
@@ -173,7 +173,7 @@
                     setSelectedItem(li);
                 };
 
-                if (li.dataset.selected) {
+                if (li.dataset.selected === 'true') {
                     setSelectedItem(li);
                 }
             });


### PR DESCRIPTION
When the `dataset.selected` evaluates to `false` it's still of type string. This will check for `if ('false')` which is true, because only an empty string evaluates to false. That is why it will select the last item in the dropdown if you set an dataset.selected attribute on all of them, regardless if they are true or false.

This change will ensure that we check if the value is actually set to 'true'.

I did not change the generated files because I do not know how they are generated. If you guys could provide some directions that would be super!