### PR TITLE
Add jsDelivr CDN usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Check out the [DEMO](http://creativeit.github.io/getmdl-select/)
 
 ## Install
 
-There are three ways to install getmdl-select:
+There are four ways to install getmdl-select:
 
  1. Using [npm](http://npmjs.org/):
     Use this command in your command line: 
@@ -26,6 +26,12 @@ There are three ways to install getmdl-select:
 
     ```bash
     git clone https://github.com/CreativeIT/getmdl-select.git
+    ```
+ 4. Include the files via [jsDelivr CDN](https://www.jsdelivr.com):
+
+    ```html
+    <script src="https://cdn.jsdelivr.net/npm/getmdl-select@2/getmdl-select.min.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/getmdl-select@2/getmdl-select.min.css">
     ```
     
     Alternatively you can [download](https://github.com/CreativeIT/getmdl-select/archive/master.zip)


### PR DESCRIPTION
I added a [jsDelivr CDN link](https://www.jsdelivr.com/) to the readme as an easier and faster option of using the project.