### PR TITLE
fix call method forEach from NodeList on old engine

### DIFF
--- a/src/js/getmdl-select.js
+++ b/src/js/getmdl-select.js
@@ -26,7 +26,7 @@
             var setSelectedItem = function (li) {
                 var value = li.textContent.trim();
                 input.value = value;
-                list.forEach(function (li) {
+                [].forEach.call(list, function (li) {
                     li.classList.remove('selected');
                 });
                 li.classList.add('selected');


### PR DESCRIPTION
fix bug #104.
NodeList calls 'forEach' on old engine. Proto NodeList have not method 'forEach'